### PR TITLE
Set up API client

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL="https://challenge.surfe.com/aloha"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "next"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --ci --passWithNoTests",
+    "test:ci": "jest --ci",
     "test:ui": "playwright test --pass-with-no-tests"
   },
   "dependencies": {

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from "@/lib/api/client";
 
-const apiClient = new ApiClient({ baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL });
+const apiClient = new ApiClient({ baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL as string });
 
 export default apiClient;

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,5 @@
+import { ApiClient } from "@/lib/api/client";
+
+const apiClient = new ApiClient({ baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL });
+
+export default apiClient;

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -1,0 +1,10 @@
+import { ApiClient } from './client';
+import { ApiClientError } from './../error';
+
+describe('ApiClient', () => {
+  describe('new', () => {
+    it('throws an error given an empty base url', () => {
+      expect(() => new ApiClient({ baseUrl: '' })).toThrowError(ApiClientError);
+    });
+  });
+});

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -16,23 +16,23 @@ export class ApiClient {
     this.RequestManager = options.requestManager || new RequestManager();
 
     if (!this.baseUrl) {
-      throw new ApiClientError('ApiClient: baseUrl is required');
+      throw new ApiClientError({message: 'ApiClient: baseUrl is required' });
     }
   }
 
-  public async get<T>(endpoint: string): Promise<T | RequestError> {
+  public async get<T>(endpoint: string): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     return await this.RequestManager.get(url);
   }
 
-  public async post<T>(endpoint: string, body: Record<string, any>): Promise<T | RequestError> {
+  public async post<T>(endpoint: string, body: Record<string, any>): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     return await this.RequestManager.post(url, body);
   }
 
-  public async put<T>(endpoint: string, body: Record<string, any>): Promise<T | RequestError> {
+  public async put<T>(endpoint: string, body: Record<string, any>): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     return await this.RequestManager.put(url, body);

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,40 @@
+import { ApiClientError } from './../error';
+import RequestManager from '../request/manager';
+
+
+interface ApiClientOptions {
+  baseUrl: string;
+  requestManager?: any
+}
+
+export class ApiClient {
+  private readonly baseUrl;
+  private RequestManager;
+
+  constructor(options: ApiClientOptions) {
+    this.baseUrl = options.baseUrl;
+    this.RequestManager = options.requestManager || new RequestManager();
+
+    if (!this.baseUrl) {
+      throw new ApiClientError('ApiClient: baseUrl is required');
+    }
+  }
+
+  public async get<T>(endpoint: string): Promise<T | RequestError> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    return await this.RequestManager.get(url);
+  }
+
+  public async post<T>(endpoint: string, body: Record<string, any>): Promise<T | RequestError> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    return await this.RequestManager.post(url, body);
+  }
+
+  public async put<T>(endpoint: string, body: Record<string, any>): Promise<T | RequestError> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    return await this.RequestManager.put(url, body);
+  }
+}

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -8,5 +8,5 @@ class BaseError extends Error {
   }
 }
 
-export class RequestError extends BaseError {}
 export class ApiClientError extends BaseError {}
+export class RequestError extends BaseError {}

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -9,3 +9,4 @@ class BaseError extends Error {
 }
 
 export class RequestError extends BaseError {}
+export class ApiClientError extends BaseError {}

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,11 @@
+class BaseError extends Error {
+  constructor({ message }: { message: string }) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, BaseError);
+    }
+  }
+}
+
+export class RequestError extends BaseError {}

--- a/src/lib/request/manager.test.ts
+++ b/src/lib/request/manager.test.ts
@@ -1,0 +1,107 @@
+import RequestManager from './manager';
+import { RequestError } from '../error';
+
+describe('RequestManager', () => {
+  const baseUrl = 'https://example.com';
+  const requestManager = new RequestManager();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('given returns data given the request is successful', async () => {
+      const url = `${baseUrl}/notes/1`;
+      const data = { id: 1, body: 'lorem ipsum' };
+
+      const mockFetch = jest.fn().mockResolvedValueOnce({
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(data),
+      });
+      global.fetch = mockFetch;
+
+      const response = await requestManager.get(url);
+
+      expect(mockFetch).toHaveBeenCalledWith(`${url}`,  {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(response).toEqual(data);
+    });
+
+    it('throws an error given the request fails', async () => {
+      const url = `${baseUrl}/notes/1`;
+
+      const mockFetch = jest.fn().mockRejectedValue(new Error('Internal Server Error'));
+      global.fetch = mockFetch;
+
+      await expect(requestManager.get(url)).rejects.toThrowError(RequestError);
+    });
+  });
+
+  describe('post', () => {
+    it('given returns data given the request is successful', async () => {
+      const url = `${baseUrl}/notes`;
+      const body = { body: 'lorem ipsum' };
+      const data = { id: 1, body: 'lorem ipsum' };
+
+      const mockFetch = jest.fn().mockResolvedValueOnce({
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(data),
+      });
+      global.fetch = mockFetch;
+
+      const result = await requestManager.post(url, body);
+
+      expect(mockFetch).toHaveBeenCalledWith(`${url}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      expect(result).toEqual(data);
+    });
+
+    it('throws an error given the request fails', async () => {
+      const url = `${baseUrl}/notes`;
+      const body = { body: 'lorem ipsum' };
+
+      const mockFetch = jest.fn().mockRejectedValue(new Error('Internal Server Error'));
+      global.fetch = mockFetch;
+
+      await expect(requestManager.post(url, body)).rejects.toThrowError(RequestError);
+    });
+  });
+
+  describe('put', () => {
+    it('given returns data given the request is successful', async () => {
+      const url = `${baseUrl}/notes/1`;
+      const body = {id: 1, body: 'lorem ipsum' };
+      const data = { id: 1, body: 'real text' };
+
+      const mockFetch = jest.fn().mockResolvedValueOnce({
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(data),
+      });
+      global.fetch = mockFetch;
+
+      const result = await requestManager.put(url, body);
+
+      expect(mockFetch).toHaveBeenCalledWith(`${url}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      expect(result).toEqual(data);
+    });
+
+    it('throws an error given the request fails', async () => {
+      const url = `${baseUrl}/notes/1`;
+      const body = { body: 'lorem ipsum' };
+
+      const mockFetch = jest.fn().mockRejectedValue(new Error('Internal Server Error'));
+      global.fetch = mockFetch;
+
+      await expect(requestManager.put(url, body)).rejects.toThrowError(RequestError);
+    });
+  });
+});

--- a/src/lib/request/manager.ts
+++ b/src/lib/request/manager.ts
@@ -1,0 +1,56 @@
+import { RequestError } from '../error';
+
+class RequestManager {
+
+  public async get<T>(url: string): Promise<T | RequestError> {
+    try {
+      const response = await fetch(`${url}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+      const responseData = await response.json();
+
+      return responseData;
+    } catch (error) {
+      throw new RequestError({ message: (error as Error)?.message });
+    }
+  }
+
+  public async post<T>(url: string, body: Record<string, any>): Promise<T | RequestError> {
+    try {
+      const response = await fetch(`${url}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const responseData = await response.json();
+
+      return responseData;
+    } catch (error) {
+      throw new RequestError({ message: (error as Error)?.message });
+    }
+  }
+
+  public async put<T>(url: string, body: Record<string, any>): Promise<T | RequestError> {
+    try {
+      const response = await fetch(`${url}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const responseData = await response.json();
+
+      return responseData;
+    } catch (error) {
+      throw new RequestError({ message: (error as Error)?.message });
+    }
+  }
+}
+
+export default RequestManager;


### PR DESCRIPTION
## What Changed 🆕

- Implement a new class `RequestManager`
- Implement a new class `ApiClient`
- Instantiate an ApiClient with the API base URL.

Closes #3

## Insight 💡

- RequestManager relies on `fetch` and can be swapped out for Axios if necessary. 
- The API url is stored as an environment variable to chengeable based on the environment (see the config on Vercel)

<img width="937" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/8e22d387-d056-4e2d-b2c5-b38dfcc9c74f">

> [!NOTE]
> I kept the tests focused on the RequestManager. More tests for the ApiClient can be implemented with [PollyJS](https://netflix.github.io/pollyjs/#/). Since I plan to implement UI tests, these additional non-UI tests have low ROI.

## Proof Of Work ✨

- Automated tests were implemented for the RequestManager`
- Manually tested on the UI

<img width="847" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/bf69b2cc-6b0a-4c06-a393-d62283908a0f">