### PR TITLE
Improve dark mode color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ The application is automatically deployed to [Vercel](https://vercel.com) on eve
 ## About
 
 This project was created and is maintained by [Olivier Robert](https://github.com/olivierobert).
+
+### Process
+
+The project was developed following this process:
+1. Build a simple prototype with the core features in this branch: https://github.com/olivierobert/aloha-notes/tree/poc. This step was done to remove any technical uncertainties and to validate the core features.
+2. Plan the final implementation with this GitHub Project: https://github.com/users/olivierobert/projects/1
+
+### Known Issues
+
+- Using a third-party for the wysiwyg editor would be easier to maintain and would provide more features, but the goal was to use as few dependencies as possible.
+- Positioning of the "User Mention" dropdown is based on the current mouse position, insteaf of the position of the caret.
+- Additional UI tests are required to validate the note editor.

--- a/src/stylesheets/components/_note-editor.scss
+++ b/src/stylesheets/components/_note-editor.scss
@@ -25,6 +25,10 @@
     padding: sizing.toRem(4) sizing.toRem(24);
 
     border-radius: sizing.toRem(24);
+
+    @media (prefers-color-scheme: dark) {
+      color: var(--accent-color);
+    }
   }
 
   &-item.active {

--- a/src/stylesheets/config/_root.scss
+++ b/src/stylesheets/config/_root.scss
@@ -18,7 +18,6 @@ $breakpoint-lg: 64rem;
 
   // Colors
   --accent-color: var(--color-blue-900);
-  --secondary-color: var(--color-rust-100);
 
   --color-blue-100: oklch(93% 0.02 250);
   --color-blue-300: oklch(84% 0.05 248);
@@ -28,7 +27,7 @@ $breakpoint-lg: 64rem;
   --color-pink-500: oklch(93.4% 0.039 350);
 
   // Typography
-  --heading-color: oklch(30% 0.1 38.7);
+  --heading-color: var(--color-blue-900);
 
   --font-size-1: 0.75em;
   --font-size-2: 0.875em;
@@ -50,7 +49,7 @@ $breakpoint-lg: 64rem;
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --body-background: oklch(0 0 0);
-    --body-color: oklch(100% 0 0);
+    // Typography
+    --color-pink-500: oklch(71.32% 0.16 350)
   }
 }


### PR DESCRIPTION
## What Changed 🆕

- Remove base colors defined  when boostrapping the project 
- Use darker shades for dark mode

## Insight 💡

As it will be the main last branch to be worked on, I have added extra details in the REAME.

## Proof Of Work ✨

|Before|After|
|-|-|
|<img width="1012" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/9f85c963-aca2-4870-ad3a-086e66be3622">|<img width="1018" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/6b23889d-d745-46e1-ac2a-e2316b2ecf5c">|
|<img width="1005" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/5d9a9bc8-1a43-424a-90c8-c5fc62e06246">|<img width="1018" alt="image" src="https://github.com/olivierobert/aloha-notes/assets/696529/1414b163-7054-4827-8541-369f2d8945b5">|